### PR TITLE
Fix login redirect route

### DIFF
--- a/frontend/src/app/auth/login/login.component.ts
+++ b/frontend/src/app/auth/login/login.component.ts
@@ -24,8 +24,8 @@ export class LoginComponent {
       next: (res) => {
         this.authService.saveToken(res.token);
         this.loading = false;
-        // Optionally navigate to dashboard or home after login
-        this.router.navigate(['/dashboard']);
+        // Optionally navigate to the login page (home) after login
+        this.router.navigate(['/login']);
       },
       error: (err) => {
         this.error = err.error || 'Login failed.';


### PR DESCRIPTION
## Summary
- navigate to an existing route after login

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c5f8d5064833191ecb98a1135a6f8