### PR TITLE
Add mocks for auth component tests

### DIFF
--- a/frontend/src/app/auth/login/login.component.spec.ts
+++ b/frontend/src/app/auth/login/login.component.spec.ts
@@ -1,14 +1,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
 
 import { LoginComponent } from './login.component';
+import { AuthService } from '../auth.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
+  const authServiceMock = {
+    login: jasmine.createSpy('login').and.returnValue(of({ token: 'test' })),
+    saveToken: jasmine.createSpy('saveToken')
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ LoginComponent ]
+      declarations: [ LoginComponent ],
+      imports: [ FormsModule, HttpClientTestingModule ],
+      providers: [ { provide: AuthService, useValue: authServiceMock } ]
     })
     .compileComponents();
 

--- a/frontend/src/app/auth/signup/signup.component.spec.ts
+++ b/frontend/src/app/auth/signup/signup.component.spec.ts
@@ -1,14 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
 
 import { SignupComponent } from './signup.component';
+import { AuthService } from '../auth.service';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
   let fixture: ComponentFixture<SignupComponent>;
+  const authServiceMock = {
+    signup: jasmine.createSpy('signup').and.returnValue(of('success'))
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SignupComponent ]
+      declarations: [ SignupComponent ],
+      imports: [ FormsModule, HttpClientTestingModule ],
+      providers: [ { provide: AuthService, useValue: authServiceMock } ]
     })
     .compileComponents();
 


### PR DESCRIPTION
## Summary
- include `FormsModule` and `HttpClientTestingModule` in login and signup tests
- provide mock `AuthService` so specs run without real HTTP

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden during package install)*

------
https://chatgpt.com/codex/tasks/task_e_684c5f9ec0988331adbd5e871dd845d4