### PR TITLE
Add user journal UI with JWT interceptor

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './auth/login/login.component';
 import { SignupComponent } from './auth/signup/signup.component';
+import { JournalComponent } from './journal/journal.component';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'signup', component: SignupComponent },
+  { path: 'dashboard', component: JournalComponent },
   { path: '', redirectTo: '/login', pathMatch: 'full' }
 ];
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -5,15 +5,18 @@ import { FormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HealthCheckComponent } from './health-check/health-check.component';
-import { HttpClientModule } from '@angular/common/http';  
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { LoginComponent } from './auth/login/login.component';
 import { SignupComponent } from './auth/signup/signup.component';
+import { JournalComponent } from './journal/journal.component';
+import { JwtInterceptor } from './auth/jwt-interceptor';
 @NgModule({
   declarations: [
     AppComponent,
     HealthCheckComponent,
     LoginComponent,
-    SignupComponent
+    SignupComponent,
+    JournalComponent
   ],
   imports: [
     BrowserModule,
@@ -21,7 +24,9 @@ import { SignupComponent } from './auth/signup/signup.component';
     HttpClientModule,
     FormsModule
   ],
-  providers: [],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/frontend/src/app/auth/jwt-interceptor.ts
+++ b/frontend/src/app/auth/jwt-interceptor.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  constructor(private authService: AuthService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.authService.getToken();
+    if (token) {
+      const cloned = req.clone({
+        headers: req.headers.set('Authorization', 'Bearer ' + token)
+      });
+      return next.handle(cloned);
+    }
+    return next.handle(req);
+  }
+}

--- a/frontend/src/app/journal.service.ts
+++ b/frontend/src/app/journal.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Journal {
+  id: string;
+  content: string;
+  createdAt: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class JournalService {
+  private apiUrl = 'http://localhost:8080/api/journal';
+
+  constructor(private http: HttpClient) {}
+
+  getJournals(): Observable<Journal[]> {
+    return this.http.get<Journal[]>(this.apiUrl);
+  }
+
+  createJournal(content: string): Observable<any> {
+    return this.http.post(this.apiUrl, { content }, { responseType: 'text' });
+  }
+}

--- a/frontend/src/app/journal/journal.component.html
+++ b/frontend/src/app/journal/journal.component.html
@@ -1,0 +1,12 @@
+<h2>Your Journal</h2>
+<form (ngSubmit)="create()" #journalForm="ngForm">
+  <textarea name="content" [(ngModel)]="content" required></textarea>
+  <br>
+  <button type="submit" [disabled]="loading">Add Entry</button>
+</form>
+
+<ul>
+  <li *ngFor="let journal of journals">
+    <strong>{{ journal.createdAt | date:'short' }}</strong> - {{ journal.content }}
+  </li>
+</ul>

--- a/frontend/src/app/journal/journal.component.ts
+++ b/frontend/src/app/journal/journal.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { JournalService, Journal } from '../journal.service';
+
+@Component({
+  selector: 'app-journal',
+  templateUrl: './journal.component.html'
+})
+export class JournalComponent implements OnInit {
+  journals: Journal[] = [];
+  content = '';
+  loading = false;
+
+  constructor(private journalService: JournalService) {}
+
+  ngOnInit(): void {
+    this.loadJournals();
+  }
+
+  loadJournals(): void {
+    this.journalService.getJournals().subscribe({
+      next: res => this.journals = res,
+      error: () => this.journals = []
+    });
+  }
+
+  create(): void {
+    if (!this.content.trim()) {
+      return;
+    }
+    this.loading = true;
+    this.journalService.createJournal(this.content).subscribe({
+      next: () => {
+        this.content = '';
+        this.loading = false;
+        this.loadJournals();
+      },
+      error: () => this.loading = false
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- implement `JournalService` for CRUD calls
- add `JournalComponent` with list and form
- route `/dashboard` to `JournalComponent`
- register JWT interceptor

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5bb918f883318345ba24159b93a8