### PR TITLE
Add configurable API base

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,3 +25,9 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+
+## API Configuration
+
+All API URLs are constructed from the `apiBase` setting defined in
+`src/environments/environment.ts` (and `environment.prod.ts` for production).
+Adjust these values if the backend runs on a different host or port.

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  private apiUrl = 'http://localhost:8080/api/auth';
+  private apiUrl = `${environment.apiBase}/auth`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/health-check.service.ts
+++ b/frontend/src/app/health-check.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class HealthCheckService {
-  private healthUrl = 'http://localhost:8080/api/health'; // Adjust if backend runs on another host/port
+  private healthUrl = `${environment.apiBase}/health`; // Adjust if backend runs on another host/port
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/journal.service.ts
+++ b/frontend/src/app/journal.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
 
 export interface Journal {
   id: string;
@@ -12,7 +13,7 @@ export interface Journal {
   providedIn: 'root'
 })
 export class JournalService {
-  private apiUrl = 'http://localhost:8080/api/journal';
+  private apiUrl = `${environment.apiBase}/journal`;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiBase: '/api'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiBase: 'http://localhost:8080/api'
 };
 
 /*


### PR DESCRIPTION
## Summary
- expose `apiBase` setting in environment configs
- use the new base URL in `AuthService`, `HealthCheckService`, and `JournalService`
- document API configuration in the README

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c85bd8b5c8331af0c2124c405247b